### PR TITLE
Reset FPU reduction, cfg_puct

### DIFF
--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -79,9 +79,9 @@ void Parameters::setup_default_parameters() {
     cfg_sgemm_exhaustive = false;
     cfg_tune_only = false;
 #endif
-    cfg_puct = 0.9f;
+    cfg_puct = 0.85f;
     cfg_softmax_temp = 1.0f;
-    cfg_fpu_reduction = 0.25f;
+    cfg_fpu_reduction = 0.0f;
     cfg_min_resign_moves = 20;
     cfg_resignpct = 10;
     cfg_noise = false;


### PR DESCRIPTION
Disables FPU reduction and restores exploration parameter to its original value, until a strength improvement for FPU reduction is proven with current network