### PR TITLE
Implement root move temperature

### DIFF
--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -45,11 +45,13 @@ int cfg_max_threads;
 int cfg_num_threads;
 int cfg_max_playouts;
 int cfg_max_visits;
-int cfg_lagbuffer_cs;
+int cfg_lagbuffer_ms;
 int cfg_resignpct;
 int cfg_noise;
 int cfg_randomize;
+int cfg_timemanage;
 int cfg_min_resign_moves;
+int cfg_root_temp_decay;
 uint64_t cfg_rng_seed;
 #ifdef USE_OPENCL
 std::vector<int> cfg_gpus;
@@ -59,6 +61,7 @@ bool cfg_tune_only;
 float cfg_puct;
 float cfg_softmax_temp;
 float cfg_fpu_reduction;
+float cfg_root_temp;
 std::string cfg_weightsfile;
 std::string cfg_logfile;
 std::string cfg_supervise;
@@ -73,7 +76,7 @@ void Parameters::setup_default_parameters() {
 
     cfg_max_playouts = MAXINT_DIV2;
     cfg_max_visits   = 800;
-    cfg_lagbuffer_cs = 100;
+    cfg_lagbuffer_ms = 50;
 #ifdef USE_OPENCL
     cfg_gpus = { };
     cfg_sgemm_exhaustive = false;
@@ -82,10 +85,13 @@ void Parameters::setup_default_parameters() {
     cfg_puct = 0.85f;
     cfg_softmax_temp = 1.0f;
     cfg_fpu_reduction = 0.0f;
+    cfg_root_temp = 1.0f;
+    cfg_root_temp_decay = 0;
     cfg_min_resign_moves = 20;
     cfg_resignpct = 10;
     cfg_noise = false;
     cfg_randomize = false;
+    cfg_timemanage = true;
     cfg_logfile_handle = nullptr;
     cfg_quiet = false;
     cfg_rng_seed = 0;

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -34,6 +34,7 @@ extern int cfg_noise;
 extern int cfg_randomize;
 extern int cfg_timemanage;
 extern int cfg_min_resign_moves;
+extern int cfg_root_temp_decay;
 extern uint64_t cfg_rng_seed;
 #ifdef USE_OPENCL
 extern std::vector<int> cfg_gpus;
@@ -43,6 +44,7 @@ extern bool cfg_tune_only;
 extern float cfg_puct;
 extern float cfg_softmax_temp;
 extern float cfg_fpu_reduction;
+extern float cfg_root_temp;
 extern std::string cfg_logfile;
 extern std::string cfg_weightsfile;
 extern std::string cfg_supervise;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -139,8 +139,15 @@ Move UCTSearch::get_best_move() {
 
     // Check whether to randomize the best move proportional
     // to the playout counts.
+   
     if (cfg_randomize) {
-        m_root->randomize_first_proportionally();
+	auto root_temperature = cfg_root_temp;
+	if (cfg_root_temp_decay > 0) {
+	    auto adjusted_ply = 1.0f + bh_.cur().game_ply() * cfg_root_temp_decay / 10.0f;
+	    root_temperature = cfg_root_temp / (1.0f + std::log(adjusted_ply));
+	    myprintf("Game ply: %d, root temperature: %5.2f \n",bh_.cur().game_ply(), root_temperature);
+	} 
+        m_root->randomize_first_proportionally(root_temperature);
     }
 
     Move bestmove = m_root->get_first_child()->get_move();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,7 +69,9 @@ static std::string parse_commandline(int argc, char *argv[]) {
         ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
                         "Resign when winrate is less than x%.")
         ("noise,n", "Apply dirichlet noise to root.")
-        ("randomize", "Randomize move selection at root (only useful for training).")
+        ("randomize,m", "Randomize move selection at root.")
+	("tempdecay,d", po::value<int>(),
+			"Use decay schedule for move selection temperature.")
         ("seed,s", po::value<std::uint64_t>(),
                    "Random number generation seed.")
         ("weights,w", po::value<std::string>(), "File with network weights.")
@@ -202,6 +204,17 @@ static std::string parse_commandline(int argc, char *argv[]) {
         // When cfg_randomize is on, we need an accurate estimate of
         // how good/bad all moves are, so turn cfg_timemanage off.
         cfg_timemanage = false;
+    }
+
+    if (vm.count("tempdecay")) {
+        cfg_root_temp_decay = vm["tempdecay"].as<int>();
+	if (cfg_root_temp_decay < 0) {
+	    myprintf("Nonsensical options: The temperature decay constant cannot be assigned a negative value, since that would turn the search useless in later game.\n");
+	    exit(EXIT_FAILURE);
+	}
+	cfg_randomize = true;
+	// Setting a value for temperature decay constant also activates --randomize.
+	// However, time management is not deactivated by --tempdecay
     }
 
     if (vm.count("playouts")) {


### PR DESCRIPTION
Introduces the option to choose root moves by exponentiated visit count, to maintain randomness and games with much less of a strength cost than move selection proportional to visit count. Also implements a command line parameter --tempdecay (-d) which takes a decay constant as parameter to dynamically reduce temperature throughout the game (logarithmic decay).