### PR TITLE
Various fixes for FPU reduction and tuning

### DIFF
--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -53,6 +53,7 @@ public:
     float get_score() const;
     void set_score(float score);
     float get_eval(int tomove) const;
+    float get_raw_eval(int tomove) const;
     double get_whiteevals() const;
     void set_visits(int visits);
     void set_whiteevals(double whiteevals);

--- a/src/config.h
+++ b/src/config.h
@@ -37,7 +37,7 @@
 #endif
 static constexpr int SELFCHECK_PROBABILITY = 2000;
 static constexpr int SELFCHECK_MIN_EXPANSIONS = 2'000'000;
-//#define USE_TUNER
+#define USE_TUNER
 
 #define PROGRAM_VERSION "v0.5"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,6 +91,7 @@ static std::string parse_commandline(int argc, char *argv[]) {
 #ifdef USE_TUNER
         ("puct", po::value<float>())
         ("fpu_reduction", po::value<float>())
+        ("fpu_static_eval", "Disable dynamic node evaluation for first play urgency")
         ("softmax_temp", po::value<float>())
 #endif
         ;
@@ -142,6 +143,9 @@ static std::string parse_commandline(int argc, char *argv[]) {
     }
     if (vm.count("fpu_reduction")) {
         cfg_fpu_reduction = vm["fpu_reduction"].as<float>();
+    }
+    if (vm.count("fpu_static_eval")) {
+        cfg_fpu_dynamic_eval = false;
     }
     if (vm.count("softmax_temp")) {
         cfg_softmax_temp = vm["softmax_temp"].as<float>();


### PR DESCRIPTION
Activates USE_TUNER by default in config.h, adds tuning option --fpu_static_eval to deactivate dynamic parent eval in FPU, and adds UCTNode::get_raw_eval which does not apply virtual losses to replace get_eval in the dynamic parent eval for FPU