### PR TITLE
Fixes to maximum search depth calculation

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -252,8 +252,7 @@ void UCTSearch::dump_analysis(int64_t elapsed, bool force_output) {
     float feval = m_root->get_eval(color);
     // UCI-like output wants a depth and a cp, so convert winrate to a cp estimate.
     int cp = 290.680623072 * tan(3.096181612 * (feval - 0.5));
-    // same for nodes to depth, assume nodes = 1.8 ^ depth.
-    int depth = log(float(m_nodes)) / log(1.8);
+    int depth = m_maxdepth;
     // To report nodes, use visits.
     //   - Only includes expanded nodes.
     //   - Includes nodes carried over from tree reuse.
@@ -261,8 +260,8 @@ void UCTSearch::dump_analysis(int64_t elapsed, bool force_output) {
     // To report nps, use m_playouts to exclude nodes added by tree reuse,
     // which is similar to a ponder hit. The user will expect to know how
     // fast nodes are being added, not how big the ponder hit was.
-    myprintf_so("info depth %d max depth %d nodes %d nps %0.f score cp %d time %lld pv %s\n",
-             depth, m_maxdepth, visits, 1000.0 * m_playouts / (elapsed + 1),
+    myprintf_so("info seldepth %d nodes %d nps %0.f score cp %d time %lld pv %s\n",
+             depth, visits, 1000.0 * m_playouts / (elapsed + 1),
              cp, elapsed, pvstring.c_str());
 }
 
@@ -424,8 +423,7 @@ Move UCTSearch::think(BoardHistory&& new_bh) {
             increment_playouts();
         }
 
-        // assume nodes = 1.8 ^ depth.
-        int depth = log(float(m_nodes)) / log(1.8);
+        int depth = m_maxdepth;
         if (depth != last_update) {
             last_update = depth;
             dump_analysis(Time.elapsed(), false);

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -95,13 +95,13 @@ private:
     std::unique_ptr<UCTNode> m_root;
     std::atomic<int> m_nodes{0};
     std::atomic<int> m_playouts{0};
+    std::atomic<int> m_maxdepth{0};
     int64_t m_target_time{0};
     int64_t m_max_time{0};
     int64_t m_start_time{0};
     std::atomic<bool> m_run{false};
     int m_maxplayouts;
     int m_maxvisits;
-    int m_maxdepth;
 
     bool quiet_ = true;
     std::atomic<bool> uci_stop{false};


### PR DESCRIPTION
Changes m_maxdepth to atomic, makes info output string UCI compatible (use seldepth for maximum search depth)